### PR TITLE
Implement ExKeysConsoleSignatureVerification

### DIFF
--- a/src/exkeys.h
+++ b/src/exkeys.h
@@ -93,6 +93,7 @@ BOOL ExKeysKeyVaultLoaded();
 
 BOOL ExKeysLoadKeyVault(const uint8_t* decrypted_kv, uint32_t length);
 BOOL ExKeysLoadKeyVaultFromPath(const char* filepath);
+BOOL ExKeysImportKey(uint32_t key_idx, uint8_t* input, uint32_t size);
 
 BOOL ExKeysIsKeySupported(uint32_t key_idx);
 BOOL ExKeysGetKey(uint32_t key_idx, uint8_t* output, uint32_t* output_size);
@@ -106,6 +107,7 @@ uint32_t ExKeysGetConsolePrivateKey(EXCRYPT_RSAPRV_1024* output);
 
 BOOL ExKeysQwNeRsaPrvCrypt(uint32_t key_idx, const uint64_t* input, uint64_t* output);
 BOOL ExKeysConsolePrivateKeySign(const uint8_t* hash, uint8_t* output_cert_sig);
+BOOL ExKeysConsoleSignatureVerification(const uint8_t* hash, uint8_t* input_signature, int32_t* compare_result);
 BOOL ExKeysPkcs1Verify(const uint8_t* hash, const uint8_t* input_sig, EXCRYPT_RSA* key);
 
 uint32_t ExKeysObscureKey(const uint8_t* input, uint8_t* output);


### PR DESCRIPTION
Tested with input data generated both via a real console and `ExKeysConsolePrivateKeySign` in the library itself.

This also somewhat implements a mechanism for ""importing"" keys standalone rather than from a keyvault, for keys like `XEKEY_CONSTANT_MASTER_KEY` that aren't in the keyvault but maybe shouldn't be included within the library itself. These keys are stored raw in the hypervisor (unlike roamable keys, that are derived), so maybe it'd be worth adding keys like this into their own map and a function like `ExKeysLoadHv` or something, with a checksum lookup table for each key.