### PR TITLE
fix: Compiling excrypt_aes.c on linux

### DIFF
--- a/src/excrypt_aes.c
+++ b/src/excrypt_aes.c
@@ -1,6 +1,13 @@
 #include <string.h>
 #include <wmmintrin.h>  //for intrinsics for AES-NI
+
+#ifdef __WIN32
 #include <intrin.h> // cpuid
+#endif
+#ifdef __linux__
+#define __cpuid(out, infoType)\
+        asm("cpuid": "=a" (out[0]), "=b" (out[1]), "=c" (out[2]), "=d" (out[3]): "a" (infoType));
+#endif
 
 #include "excrypt.h"
 


### PR DESCRIPTION
Creates a macro around cpuid for compatibility with linux hosts.