### PR TITLE
fix: replace unsigned long usage in excrypt_aes.c with uint32_t

### DIFF
--- a/src/excrypt_aes.c
+++ b/src/excrypt_aes.c
@@ -123,9 +123,9 @@ void ExCryptAesKey(EXCRYPT_AES_STATE* state, const uint8_t* key)
   }
   else
   {
-    rijndaelSetupEncrypt((unsigned long*)state->keytabenc, key, 128);
+    rijndaelSetupEncrypt((uint32_t*)state->keytabenc, key, 128);
     memcpy(state->keytabdec, state->keytabenc, sizeof(state->keytabdec));
-    rijndaelSetupDecrypt((unsigned long*)state->keytabdec, key, 128);
+    rijndaelSetupDecrypt((uint32_t*)state->keytabdec, key, 128);
   }
 }
 
@@ -133,11 +133,11 @@ void ExCryptAesEcb(const EXCRYPT_AES_STATE* state, const uint8_t* input, uint8_t
 {
   if (encrypt)
   {
-    AesEnc((unsigned long*)state->keytabenc, 10, input, output);
+    AesEnc((uint32_t*)state->keytabenc, 10, input, output);
   }
   else
   {
-    AesDec((unsigned long*)state->keytabdec, 10, input, output);
+    AesDec((uint32_t*)state->keytabdec, 10, input, output);
   }
 }
 
@@ -149,7 +149,7 @@ void xorWithIv(const uint8_t* input, uint8_t* output, const uint8_t* iv)
   }
 }
 
-void rijndaelCbcEncrypt(const unsigned long* rk, const uint8_t* input, uint32_t input_size, uint8_t* output, uint8_t* feed)
+void rijndaelCbcEncrypt(const uint32_t* rk, const uint8_t* input, uint32_t input_size, uint8_t* output, uint8_t* feed)
 {
   uint8_t* iv = feed;
   for (uint32_t i = 0; i < input_size; i += AES_BLOCKLEN)
@@ -164,7 +164,7 @@ void rijndaelCbcEncrypt(const unsigned long* rk, const uint8_t* input, uint32_t 
   memcpy(feed, iv, AES_BLOCKLEN);
 }
 
-void rijndaelCbcDecrypt(const unsigned long* rk, const uint8_t* input, uint32_t input_size, uint8_t* output, uint8_t* feed)
+void rijndaelCbcDecrypt(const uint32_t* rk, const uint8_t* input, uint32_t input_size, uint8_t* output, uint8_t* feed)
 {
   uint8_t current_input[AES_BLOCKLEN];
   uint8_t iv[AES_BLOCKLEN];
@@ -189,17 +189,17 @@ void ExCryptAesCbc(const EXCRYPT_AES_STATE* state, const uint8_t* input, uint32_
 {
   if (encrypt)
   {
-    rijndaelCbcEncrypt((unsigned long*)state->keytabenc, input, input_size, output, feed);
+    rijndaelCbcEncrypt((uint32_t*)state->keytabenc, input, input_size, output, feed);
   }
   else
   {
-    rijndaelCbcDecrypt((unsigned long*)state->keytabdec, input, input_size, output, feed);
+    rijndaelCbcDecrypt((uint32_t*)state->keytabdec, input, input_size, output, feed);
   }
 }
 
-unsigned long* aesschedule_dectable(EXCRYPT_AES_SCHEDULE* state)
+uint32_t* aesschedule_dectable(EXCRYPT_AES_SCHEDULE* state)
 {
-  return (unsigned long*)&state->keytab[state->num_rounds + 1]; // dec table starts at last entry of enc table
+  return (uint32_t*)&state->keytab[state->num_rounds + 1]; // dec table starts at last entry of enc table
 }
 
 void ExCryptAesCreateKeySchedule(const uint8_t* key, uint32_t key_size, EXCRYPT_AES_SCHEDULE* state)
@@ -211,7 +211,7 @@ void ExCryptAesCreateKeySchedule(const uint8_t* key, uint32_t key_size, EXCRYPT_
 
   state->num_rounds = (key_size >> 2) + 5; // seems to be nr - 1 ?
 
-  rijndaelSetupEncrypt((unsigned long*)state->keytab, key, key_size * 8);
+  rijndaelSetupEncrypt((uint32_t*)state->keytab, key, key_size * 8);
   memcpy(aesschedule_dectable(state), state->keytab, (state->num_rounds + 2) * 0x10);
   rijndaelSetupDecrypt(aesschedule_dectable(state), key, key_size * 8);
 }
@@ -222,7 +222,7 @@ void ExCryptAesCbcEncrypt(EXCRYPT_AES_SCHEDULE* state, const uint8_t* input, uin
   for (uint32_t i = 0; i < input_size; i += AES_BLOCKLEN)
   {
     xorWithIv(input, output, iv);
-    rijndaelEncrypt((unsigned long*)state->keytab, state->num_rounds + 1, output, output);
+    rijndaelEncrypt((uint32_t*)state->keytab, state->num_rounds + 1, output, output);
     iv = output;
     output += AES_BLOCKLEN;
     input += AES_BLOCKLEN;


### PR DESCRIPTION
When utilizing idaxex on Linux I was still experiencing segmentation faults due to `unsigned long` usage despite the fixes mentioned in #12  -- this should resolve the other outstanding areas in `excrypt_aes.c` where `unsigned long` was being used.